### PR TITLE
Update theme plugin to improve 3d imagery on mobile

### DIFF
--- a/config/lux.config.json
+++ b/config/lux.config.json
@@ -28,6 +28,7 @@
       "name": "displayQuality",
       "value": {
         "startingQualityLevel": "high",
+        "startingMobileQualityLevel": "high",
         "low": {
           "sse": 4,
           "fxaa": false,
@@ -735,7 +736,7 @@
       "tabId": "lux2d",
       "pathToPrintPortal": "https://3dprint-test.geoportail.lu/commande",
       "tabIdPrint": "luxprint"
-},
+    },
     {
       "name": "@geoportallux/lux-3dviewer-plugin-create-link",
       "entry": "plugins/@geoportallux/lux-3dviewer-plugin-create-link/index.js",

--- a/plugins/package-lock.json
+++ b/plugins/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal": "^1.2.2",
         "@geoportallux/lux-3dviewer-plugin-create-link": "^1.0.0",
-        "@geoportallux/lux-3dviewer-themesync": "^1.4.0",
+        "@geoportallux/lux-3dviewer-themesync": "^1.4.1-alpha",
         "@vcmap/cesium-filters": "^2.0.0",
         "@vcmap/cesium-inspector": "^2.0.0",
         "@vcmap/clipping-tool": "^3.0.0",
@@ -186,9 +186,9 @@
       }
     },
     "node_modules/@geoportallux/lux-3dviewer-themesync": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-themesync/-/lux-3dviewer-themesync-1.4.0.tgz",
-      "integrity": "sha512-0ZEUVj90sTZSkXSjOoFQZbRFs8qZu7FFyfJ5BLo02pWFBT2JdKUGbgU9Y0uNYd4nVdzdpBoHk9h3TdH+Pq7Kqw==",
+      "version": "1.4.1-alpha",
+      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-themesync/-/lux-3dviewer-themesync-1.4.1-alpha.tgz",
+      "integrity": "sha512-e700ihuwIZS3sU8tlhs+FQlXRT53T+rPhx/eh5Zwcf7NMbzRDgJTzkZdSceEmy+gR93hdfy05WD/48m9MY8Ghg==",
       "license": "GPL-3.0",
       "peerDependencies": {
         "@vcmap/core": "^6.2.2",

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -31,7 +31,7 @@
     "@vcmap/cesium-inspector": "^2.0.0",
     "@vcmap/event-control": "^1.0.1",
     "@vcmap/dynamic-layer": "^1.0.0",
-    "@geoportallux/lux-3dviewer-themesync": "^1.4.0",
+    "@geoportallux/lux-3dviewer-themesync": "^1.4.1-alpha",
     "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal": "^1.2.2",
     "@geoportallux/lux-3dviewer-plugin-create-link": "^1.0.0"
   },


### PR DESCRIPTION
PR updates lux-3dviewer-themesync to 1.4.1-alpha to deploy https://github.com/Geoportail-Luxembourg/3dviewer-themesync/pull/17 on gh-pages

Todo:

- [ ] Update plugin to non-alpha before merging

=> PR seems unnecessary as https://github.com/Geoportail-Luxembourg/3dviewer/commit/ebbc6b87c527d4148edfd3b50efee771f0983421 improves both display quality of CesiumTilesetLayers and WMTSs.