### PR TITLE
Add auth to 3dviewer

### DIFF
--- a/.github/trigger-gitlab-pipeline.yml
+++ b/.github/trigger-gitlab-pipeline.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - lux
-      - lux-lux-v6.3
+      - lux-v6.3
       - github-actions
       - GSLUX-809-dev
   workflow_dispatch:

--- a/.github/trigger-gitlab-pipeline.yml
+++ b/.github/trigger-gitlab-pipeline.yml
@@ -6,6 +6,7 @@ on:
       - lux
       - lux-lux-v6.3
       - github-actions
+      - GSLUX-809-dev
   workflow_dispatch:
 
 jobs:

--- a/.github/trigger-gitlab-pipeline.yml
+++ b/.github/trigger-gitlab-pipeline.yml
@@ -1,0 +1,23 @@
+name: Trigger GitLab pipeline
+
+on:
+  push:
+    branches:
+      - lux
+      - lux-lux-v6.3
+      - github-actions
+  workflow_dispatch:
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger GitLab pipeline
+        run: |
+          curl --fail --request POST \
+            --form token="${{ secrets.GITLAB_TRIGGER_TOKEN }}" \
+            --form ref="${{ github.ref_name }}" \
+            --form "variables[GITHUB_REPOSITORY]=${{ github.repository }}" \
+            --form "variables[GITHUB_SHA]=${{ github.sha }}" \
+            --form "variables[GITHUB_REF]=${{ github.ref }}" \
+            "${{ secrets.GITLAB_WEBHOOK_URL }}"

--- a/config/lux.config.json
+++ b/config/lux.config.json
@@ -733,7 +733,7 @@
     {
       "name": "@geoportallux/lux-3dviewer-plugin-auth",
       "entry": "plugins/@geoportallux/lux-3dviewer-plugin-auth/index.js",
-      "baseUrl": "https://map.geoportail.lu",
+      "baseUrl": "https://migration.geoportail.lu",
       "credentials": "include"
     },
     {

--- a/config/lux.config.json
+++ b/config/lux.config.json
@@ -724,6 +724,7 @@
       "luxI18nUrl": "https://map.geoportail.lu/static/0",
       "luxOwsUrl": "https://wms.geoportail.lu/public_map_layers/service",
       "luxWmtsUrl": "https://wmts3.geoportail.lu/mapproxy_4_v3/wmts",
+      "luxProxyUrl": "https://wmsproxy.geoportail.lu/ogcproxywms",
       "lux3dUrl": "https://acts3.geoportail.lu/3d-data/3d-tiles",
       "luxLegendUrl": "https://3d.geoportail.lu/legends/get_html",
       "luxDefaultBaselayer": "orthogr_2013_global",

--- a/config/lux.config.json
+++ b/config/lux.config.json
@@ -725,7 +725,6 @@
       "luxOwsUrl": "https://wms.geoportail.lu/public_map_layers/service",
       "luxWmtsUrl": "https://wmts3.geoportail.lu/mapproxy_4_v3/wmts",
       "luxProxyUrl": "https://wmsproxy.geoportail.lu/ogcproxywms",
-      "lux3dUrl": "https://acts3.geoportail.lu/3d-data/3d-tiles",
       "luxLegendUrl": "https://3d.geoportail.lu/legends/get_html",
       "luxDefaultBaselayer": "orthogr_2013_global",
       "luxGeonetworkUrl": "https://geocatalogue.geoportail.lu/geonetwork/srv",

--- a/config/lux.config.json
+++ b/config/lux.config.json
@@ -722,19 +722,19 @@
       "entry": "plugins/@geoportallux/lux-3dviewer-themesync/index.js",
       "luxThemesUrl": "https://map.geoportail.lu/themes?limit=30&partitionlimit=5&interface=main&background=background",
       "luxI18nUrl": "https://map.geoportail.lu/static/0",
-      "luxOwsUrl": "https://map.geoportail.lu/public_map_layers/service",
-      "luxWmtsUrl": "https://map.geoportail.lu/mapproxy_4_v3/wmts",
+      "luxOwsUrl": "https://wms.geoportail.lu/public_map_layers/service",
+      "luxWmtsUrl": "https://wmts3.geoportail.lu/mapproxy_4_v3/wmts",
       "lux3dUrl": "https://acts3.geoportail.lu/3d-data/3d-tiles",
       "luxLegendUrl": "https://3d.geoportail.lu/legends/get_html",
       "luxDefaultBaselayer": "orthogr_2013_global",
       "luxGeonetworkUrl": "https://geocatalogue.geoportail.lu/geonetwork/srv",
-      "credentials": "same-origin"
+      "credentials": "include"
     },
     {
       "name": "@geoportallux/lux-3dviewer-plugin-auth",
       "entry": "plugins/@geoportallux/lux-3dviewer-plugin-auth/index.js",
       "baseUrl": "https://map.geoportail.lu",
-      "credentials": "same-origin"
+      "credentials": "include"
     },
     {
       "name": "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal",

--- a/config/lux.config.json
+++ b/config/lux.config.json
@@ -646,6 +646,10 @@
   ],
   "plugins": [
     {
+      "name": "@geoportallux/lux-3dviewer-plugin-statesync",
+      "entry": "plugins/@geoportallux/lux-3dviewer-plugin-statesync/index.js"
+    },
+    {
       "name": "@vcmap/search-coordinate",
       "entry": "plugins/@vcmap/search-coordinate/index.js",
       "searchProjections": [

--- a/config/lux.config.json
+++ b/config/lux.config.json
@@ -720,7 +720,7 @@
     {
       "name": "@geoportallux/lux-3dviewer-themesync",
       "entry": "plugins/@geoportallux/lux-3dviewer-themesync/index.js",
-      "luxThemesUrl": "https://migration.geoportail.lu/themes?limit=30&partitionlimit=5&interface=main&background=background",
+      "luxThemesUrl": "https://map.geoportail.lu/themes?limit=30&partitionlimit=5&interface=main&background=background",
       "luxI18nUrl": "https://map.geoportail.lu/static/0",
       "luxOwsUrl": "https://wms.geoportail.lu/public_map_layers/service",
       "luxWmtsUrl": "https://wmts3.geoportail.lu/mapproxy_4_v3/wmts",
@@ -733,7 +733,7 @@
     {
       "name": "@geoportallux/lux-3dviewer-plugin-auth",
       "entry": "plugins/@geoportallux/lux-3dviewer-plugin-auth/index.js",
-      "baseUrl": "https://migration.geoportail.lu",
+      "baseUrl": "https://map.geoportail.lu",
       "credentials": "include"
     },
     {

--- a/config/lux.config.json
+++ b/config/lux.config.json
@@ -650,6 +650,38 @@
       "entry": "plugins/@geoportallux/lux-3dviewer-plugin-statesync/index.js"
     },
     {
+      "name": "@geoportallux/lux-3dviewer-themesync",
+      "entry": "plugins/@geoportallux/lux-3dviewer-themesync/index.js",
+      "luxThemesUrl": "https://map.geoportail.lu/themes?limit=30&partitionlimit=5&interface=main&background=background",
+      "luxI18nUrl": "https://map.geoportail.lu/static/0",
+      "luxOwsUrl": "https://wms.geoportail.lu/public_map_layers/service",
+      "luxWmtsUrl": "https://wmts3.geoportail.lu/mapproxy_4_v3/wmts",
+      "luxProxyUrl": "https://wmsproxy.geoportail.lu/ogcproxywms",
+      "luxLegendUrl": "https://3d.geoportail.lu/legends/get_html",
+      "luxDefaultBaselayer": "orthogr_2013_global",
+      "luxGeonetworkUrl": "https://geocatalogue.geoportail.lu/geonetwork/srv",
+      "credentials": "include"
+    },
+    {
+      "name": "@geoportallux/lux-3dviewer-plugin-auth",
+      "entry": "plugins/@geoportallux/lux-3dviewer-plugin-auth/index.js",
+      "baseUrl": "https://map.geoportail.lu",
+      "credentials": "include"
+    },
+    {
+      "name": "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal",
+      "entry": "plugins/@geoportallux/lux-3dviewer-plugin-back-to-2d-portal/index.js",
+      "pathTo2dGeoportal": "https://map.geoportail.lu/",
+      "tabId": "lux2d",
+      "pathToPrintPortal": "https://3dprint.geoportail.lu/commande",
+      "tabIdPrint": "luxprint"
+    },
+    {
+      "name": "@geoportallux/lux-3dviewer-plugin-create-link",
+      "entry": "plugins/@geoportallux/lux-3dviewer-plugin-create-link/index.js",
+      "pathToUrlShortenerApi": "https://map.geoportail.lu/short/create"
+    },
+    {
       "name": "@vcmap/search-coordinate",
       "entry": "plugins/@vcmap/search-coordinate/index.js",
       "searchProjections": [
@@ -720,38 +752,6 @@
     {
       "name": "@vcmap/cesium-filters",
       "entry": "plugins/@vcmap/cesium-filters/index.js"
-    },
-    {
-      "name": "@geoportallux/lux-3dviewer-themesync",
-      "entry": "plugins/@geoportallux/lux-3dviewer-themesync/index.js",
-      "luxThemesUrl": "https://map.geoportail.lu/themes?limit=30&partitionlimit=5&interface=main&background=background",
-      "luxI18nUrl": "https://map.geoportail.lu/static/0",
-      "luxOwsUrl": "https://wms.geoportail.lu/public_map_layers/service",
-      "luxWmtsUrl": "https://wmts3.geoportail.lu/mapproxy_4_v3/wmts",
-      "luxProxyUrl": "https://wmsproxy.geoportail.lu/ogcproxywms",
-      "luxLegendUrl": "https://3d.geoportail.lu/legends/get_html",
-      "luxDefaultBaselayer": "orthogr_2013_global",
-      "luxGeonetworkUrl": "https://geocatalogue.geoportail.lu/geonetwork/srv",
-      "credentials": "include"
-    },
-    {
-      "name": "@geoportallux/lux-3dviewer-plugin-auth",
-      "entry": "plugins/@geoportallux/lux-3dviewer-plugin-auth/index.js",
-      "baseUrl": "https://map.geoportail.lu",
-      "credentials": "include"
-    },
-    {
-      "name": "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal",
-      "entry": "plugins/@geoportallux/lux-3dviewer-plugin-back-to-2d-portal/index.js",
-      "pathTo2dGeoportal": "https://map.geoportail.lu/",
-      "tabId": "lux2d",
-      "pathToPrintPortal": "https://3dprint.geoportail.lu/commande",
-      "tabIdPrint": "luxprint"
-    },
-    {
-      "name": "@geoportallux/lux-3dviewer-plugin-create-link",
-      "entry": "plugins/@geoportallux/lux-3dviewer-plugin-create-link/index.js",
-      "pathToUrlShortenerApi": "https://map.geoportail.lu/short/create"
     }
   ]
 }

--- a/config/lux.config.json
+++ b/config/lux.config.json
@@ -720,14 +720,21 @@
     {
       "name": "@geoportallux/lux-3dviewer-themesync",
       "entry": "plugins/@geoportallux/lux-3dviewer-themesync/index.js",
-      "luxThemesUrl": "https://map.geoportail.lu/themes?limit=30&partitionlimit=5&interface=main&cache_version=0&background=background",
+      "luxThemesUrl": "https://map.geoportail.lu/themes?limit=30&partitionlimit=5&interface=main&background=background",
       "luxI18nUrl": "https://map.geoportail.lu/static/0",
-      "luxOwsUrl": "https://wms.geoportail.lu/public_map_layers/service",
-      "luxWmtsUrl": "https://wmts3.geoportail.lu/mapproxy_4_v3/wmts",
+      "luxOwsUrl": "https://map.geoportail.lu/public_map_layers/service",
+      "luxWmtsUrl": "https://map.geoportail.lu/mapproxy_4_v3/wmts",
       "lux3dUrl": "https://acts3.geoportail.lu/3d-data/3d-tiles",
       "luxLegendUrl": "https://3d.geoportail.lu/legends/get_html",
       "luxDefaultBaselayer": "orthogr_2013_global",
-      "luxGeonetworkUrl": "https://geocatalogue.geoportail.lu/geonetwork/srv"
+      "luxGeonetworkUrl": "https://geocatalogue.geoportail.lu/geonetwork/srv",
+      "credentials": "same-origin"
+    },
+    {
+      "name": "@geoportallux/lux-3dviewer-plugin-auth",
+      "entry": "plugins/@geoportallux/lux-3dviewer-plugin-auth/index.js",
+      "baseUrl": "https://map.geoportail.lu",
+      "credentials": "same-origin"
     },
     {
       "name": "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal",

--- a/config/lux.config.json
+++ b/config/lux.config.json
@@ -720,7 +720,7 @@
     {
       "name": "@geoportallux/lux-3dviewer-themesync",
       "entry": "plugins/@geoportallux/lux-3dviewer-themesync/index.js",
-      "luxThemesUrl": "https://map.geoportail.lu/themes?limit=30&partitionlimit=5&interface=main&background=background",
+      "luxThemesUrl": "https://migration.geoportail.lu/themes?limit=30&partitionlimit=5&interface=main&background=background",
       "luxI18nUrl": "https://map.geoportail.lu/static/0",
       "luxOwsUrl": "https://wms.geoportail.lu/public_map_layers/service",
       "luxWmtsUrl": "https://wmts3.geoportail.lu/mapproxy_4_v3/wmts",

--- a/config/lux.i18n.de.config.json
+++ b/config/lux.i18n.de.config.json
@@ -1,4 +1,5 @@
 {
+  "_id": "luxI18nDe",
   "name": "DE translations",
   "i18n": [
     {

--- a/config/lux.i18n.en.config.json
+++ b/config/lux.i18n.en.config.json
@@ -1,4 +1,5 @@
 {
+  "_id": "luxI18nEn",
   "name": "EN translations",
   "i18n": [
     {

--- a/config/lux.i18n.fr.config.json
+++ b/config/lux.i18n.fr.config.json
@@ -1,4 +1,5 @@
 {
+  "_id": "luxI18nFr",
   "name": "FR translations",
   "i18n": [
     {

--- a/config/lux.i18n.lb.config.json
+++ b/config/lux.i18n.lb.config.json
@@ -1,4 +1,5 @@
 {
+  "_id": "luxI18nLb",
   "name": "LB translations",
   "i18n": [
     {

--- a/config/lux.theming.config.json
+++ b/config/lux.theming.config.json
@@ -1,4 +1,5 @@
 {
+  "_id": "luxTheming",
   "name": "Luxembourg theming",
   "uiConfig": [
     {

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,42 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Hashed assets - cache forever (they have content-based hashes)
+    location ~* \-[a-f0-9]{8}\.(js|css)$ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        access_log off;
+    }
+
+    # Entry point files and library loaders - never cache
+    location ~* (index\.html|start\.js|ui\.js|vue\.js|vuetify\.js|ol\.js|cesium\.js|core\.js)$ {
+        add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+        add_header Pragma "no-cache";
+        add_header Expires "0";
+        expires off;
+    }
+
+    # Plugin files - short cache
+    location /plugins/ {
+        add_header Cache-Control "public, max-age=3600";
+    }
+
+    # Config files - no cache
+    location ~* \.json$ {
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+    }
+
+    # All other static assets - moderate cache
+    location / {
+        try_files $uri $uri/ /index.html;
+        add_header Cache-Control "public, max-age=3600";
+    }
+
+    # Gzip compression
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/javascript application/xml+rss application/json;
+}

--- a/plugins/package-lock.json
+++ b/plugins/package-lock.json
@@ -8,7 +8,7 @@
         "@geoportallux/lux-3dviewer-plugin-auth": "1.0.1",
         "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal": "^1.2.2",
         "@geoportallux/lux-3dviewer-plugin-create-link": "^1.0.0",
-        "@geoportallux/lux-3dviewer-plugin-statesync": "1.0.0-dev",
+        "@geoportallux/lux-3dviewer-plugin-statesync": "1.0.0-alpha",
         "@geoportallux/lux-3dviewer-themesync": "1.5.2-dev",
         "@vcmap/cesium-filters": "^2.0.0",
         "@vcmap/cesium-inspector": "^2.0.0",
@@ -204,9 +204,9 @@
       }
     },
     "node_modules/@geoportallux/lux-3dviewer-plugin-statesync": {
-      "version": "1.0.0-dev",
-      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-plugin-statesync/-/lux-3dviewer-plugin-statesync-1.0.0-dev.tgz",
-      "integrity": "sha512-Mx8+3SSdXyO05rsuVJ7yO3QWD+u/3yQ5meHHafMhdIKSrVQJDcutvjAhDELQDpkTtQr29pA/6UBeR/NlH9yPRA==",
+      "version": "1.0.0-alpha",
+      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-plugin-statesync/-/lux-3dviewer-plugin-statesync-1.0.0-alpha.tgz",
+      "integrity": "sha512-RlbPlmKw5y6DQKo3M8tTfpoGVsx3qfqGha/uAYjtzK3BTUNKln5DvG8MOewRTyYdmap0gtT44Qpae9eQkxM3ZA==",
       "license": "GPL-3.0",
       "peerDependencies": {
         "@vcmap/core": "^6.3.8",

--- a/plugins/package-lock.json
+++ b/plugins/package-lock.json
@@ -8,7 +8,7 @@
         "@geoportallux/lux-3dviewer-plugin-auth": "^1.0.0",
         "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal": "^1.2.2",
         "@geoportallux/lux-3dviewer-plugin-create-link": "^1.0.0",
-        "@geoportallux/lux-3dviewer-themesync": "1.5.1-dev",
+        "@geoportallux/lux-3dviewer-themesync": "1.5.1-alpha",
         "@vcmap/cesium-filters": "^2.0.0",
         "@vcmap/cesium-inspector": "^2.0.0",
         "@vcmap/clipping-tool": "^3.0.0",
@@ -203,9 +203,9 @@
       }
     },
     "node_modules/@geoportallux/lux-3dviewer-themesync": {
-      "version": "1.5.1-dev",
-      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-themesync/-/lux-3dviewer-themesync-1.5.1-dev.tgz",
-      "integrity": "sha512-sHqzAqeH3l6O4+AAjgdiEyytu32GfYDOkilNennj4MOGUz1ej2oDEPneZPz+DK49fQimLmbg5IRMMuRf5P1cKw==",
+      "version": "1.5.1-alpha",
+      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-themesync/-/lux-3dviewer-themesync-1.5.1-alpha.tgz",
+      "integrity": "sha512-rSfA6MspxIKS6Nwly5oYQML5jVti8M+PsEXiY/ZaAlA4TPwHQUb/2JZ9L15L7cqAsflFBar3HkRHt8K23QJCwg==",
       "license": "GPL-3.0",
       "dependencies": {
         "@zip.js/zip.js": "2.7.34"

--- a/plugins/package-lock.json
+++ b/plugins/package-lock.json
@@ -8,7 +8,8 @@
         "@geoportallux/lux-3dviewer-plugin-auth": "1.0.1",
         "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal": "^1.2.2",
         "@geoportallux/lux-3dviewer-plugin-create-link": "^1.0.0",
-        "@geoportallux/lux-3dviewer-themesync": "1.5.1",
+        "@geoportallux/lux-3dviewer-plugin-statesync": "1.0.0-dev",
+        "@geoportallux/lux-3dviewer-themesync": "1.5.2-dev",
         "@vcmap/cesium-filters": "^2.0.0",
         "@vcmap/cesium-inspector": "^2.0.0",
         "@vcmap/clipping-tool": "^3.0.0",
@@ -202,10 +203,20 @@
         "vuetify": "^3.7.12"
       }
     },
+    "node_modules/@geoportallux/lux-3dviewer-plugin-statesync": {
+      "version": "1.0.0-dev",
+      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-plugin-statesync/-/lux-3dviewer-plugin-statesync-1.0.0-dev.tgz",
+      "integrity": "sha512-Mx8+3SSdXyO05rsuVJ7yO3QWD+u/3yQ5meHHafMhdIKSrVQJDcutvjAhDELQDpkTtQr29pA/6UBeR/NlH9yPRA==",
+      "license": "GPL-3.0",
+      "peerDependencies": {
+        "@vcmap/core": "^6.3.8",
+        "@vcmap/ui": "^6.3.8"
+      }
+    },
     "node_modules/@geoportallux/lux-3dviewer-themesync": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-themesync/-/lux-3dviewer-themesync-1.5.1.tgz",
-      "integrity": "sha512-Bqeunv0OWLmmHSgn0fwOuX3ZLsbhPcw6oXY4H1lE8CM0iSHLul+O4OeWPLFoJFiKSgTbfA8QZEsE5onD3QIR9Q==",
+      "version": "1.5.2-dev",
+      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-themesync/-/lux-3dviewer-themesync-1.5.2-dev.tgz",
+      "integrity": "sha512-97qZDxDZsXoRyVfpHvmSNMgTs+Ab4HlKjptLb56mfY2Ld0qhSBvtdzrmc0VUITvHVm8FUTfKTtZ7j522N+snqw==",
       "license": "GPL-3.0",
       "dependencies": {
         "@zip.js/zip.js": "2.7.34"
@@ -1266,9 +1277,9 @@
       }
     },
     "node_modules/@vcmap/ui": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/@vcmap/ui/-/ui-6.3.6.tgz",
-      "integrity": "sha512-gljlsbTo+oojkD8kGWku8zuX+gUKGc4GRyaUY1fJ14iKI2Xygk/oQgvuZjBdgu5IhxsVuClXJ2cfOeC9ENqgAQ==",
+      "version": "6.3.9",
+      "resolved": "https://registry.npmjs.org/@vcmap/ui/-/ui-6.3.9.tgz",
+      "integrity": "sha512-EB5sGe4LB1WFaPVfdN5JTVx0LACb5wIcCBhc2/aPyC2pwYzrO0U4Ud38YtJMhGgM3Q2QyDCu+9y7/fCq8vBkDQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
@@ -1290,7 +1301,7 @@
       },
       "peerDependencies": {
         "@vcmap-cesium/engine": "^11.0.5",
-        "@vcmap/core": "^6.3.5",
+        "@vcmap/core": "^6.3.8",
         "ol": "^10.4.0",
         "vue": "~3.4.38",
         "vuetify": "~3.7.14"

--- a/plugins/package-lock.json
+++ b/plugins/package-lock.json
@@ -8,8 +8,8 @@
         "@geoportallux/lux-3dviewer-plugin-auth": "1.0.1",
         "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal": "^1.2.2",
         "@geoportallux/lux-3dviewer-plugin-create-link": "^1.0.0",
-        "@geoportallux/lux-3dviewer-plugin-statesync": "1.0.0-alpha",
-        "@geoportallux/lux-3dviewer-themesync": "1.5.2-dev",
+        "@geoportallux/lux-3dviewer-plugin-statesync": "1.0.0",
+        "@geoportallux/lux-3dviewer-themesync": "1.5.2",
         "@vcmap/cesium-filters": "^2.0.0",
         "@vcmap/cesium-inspector": "^2.0.0",
         "@vcmap/clipping-tool": "^3.0.0",
@@ -204,9 +204,9 @@
       }
     },
     "node_modules/@geoportallux/lux-3dviewer-plugin-statesync": {
-      "version": "1.0.0-alpha",
-      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-plugin-statesync/-/lux-3dviewer-plugin-statesync-1.0.0-alpha.tgz",
-      "integrity": "sha512-RlbPlmKw5y6DQKo3M8tTfpoGVsx3qfqGha/uAYjtzK3BTUNKln5DvG8MOewRTyYdmap0gtT44Qpae9eQkxM3ZA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-plugin-statesync/-/lux-3dviewer-plugin-statesync-1.0.0.tgz",
+      "integrity": "sha512-8ihU0s20YGAivJsYWhCM5leffagOXeOkfRjPVNKzoWTiDZZjq9ziXYkZm9jWwny6t+RnOoPfjUKlhpgAy5FbWw==",
       "license": "GPL-3.0",
       "peerDependencies": {
         "@vcmap/core": "^6.3.8",
@@ -214,9 +214,9 @@
       }
     },
     "node_modules/@geoportallux/lux-3dviewer-themesync": {
-      "version": "1.5.2-dev",
-      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-themesync/-/lux-3dviewer-themesync-1.5.2-dev.tgz",
-      "integrity": "sha512-97qZDxDZsXoRyVfpHvmSNMgTs+Ab4HlKjptLb56mfY2Ld0qhSBvtdzrmc0VUITvHVm8FUTfKTtZ7j522N+snqw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-themesync/-/lux-3dviewer-themesync-1.5.2.tgz",
+      "integrity": "sha512-/GG89os4NJNG1TJvfhTuTcEymbm58e0gMtdM2G90ObUfInpacsGKql1WbArEZ9RviBOseK4g3ozD0gBgpypCfA==",
       "license": "GPL-3.0",
       "dependencies": {
         "@zip.js/zip.js": "2.7.34"

--- a/plugins/package-lock.json
+++ b/plugins/package-lock.json
@@ -8,7 +8,7 @@
         "@geoportallux/lux-3dviewer-plugin-auth": "^1.0.0",
         "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal": "^1.2.2",
         "@geoportallux/lux-3dviewer-plugin-create-link": "^1.0.0",
-        "@geoportallux/lux-3dviewer-themesync": "^1.5.0",
+        "@geoportallux/lux-3dviewer-themesync": "1.5.1-dev",
         "@vcmap/cesium-filters": "^2.0.0",
         "@vcmap/cesium-inspector": "^2.0.0",
         "@vcmap/clipping-tool": "^3.0.0",
@@ -203,9 +203,9 @@
       }
     },
     "node_modules/@geoportallux/lux-3dviewer-themesync": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-themesync/-/lux-3dviewer-themesync-1.5.0.tgz",
-      "integrity": "sha512-Btcfm7veq7utPJkfJD0l8fWOyMAHkdOcUV/VjVfGzDSWtAyZAcqh9r6Z0M86CweZ0Qz/0GChd+3fVNbbvU2O2g==",
+      "version": "1.5.1-dev",
+      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-themesync/-/lux-3dviewer-themesync-1.5.1-dev.tgz",
+      "integrity": "sha512-sHqzAqeH3l6O4+AAjgdiEyytu32GfYDOkilNennj4MOGUz1ej2oDEPneZPz+DK49fQimLmbg5IRMMuRf5P1cKw==",
       "license": "GPL-3.0",
       "dependencies": {
         "@zip.js/zip.js": "2.7.34"

--- a/plugins/package-lock.json
+++ b/plugins/package-lock.json
@@ -5,10 +5,10 @@
   "packages": {
     "": {
       "dependencies": {
-        "@geoportallux/lux-3dviewer-plugin-auth": "1.0.1-dev",
+        "@geoportallux/lux-3dviewer-plugin-auth": "1.0.1",
         "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal": "^1.2.2",
         "@geoportallux/lux-3dviewer-plugin-create-link": "^1.0.0",
-        "@geoportallux/lux-3dviewer-themesync": "1.5.1-beta",
+        "@geoportallux/lux-3dviewer-themesync": "1.5.1",
         "@vcmap/cesium-filters": "^2.0.0",
         "@vcmap/cesium-inspector": "^2.0.0",
         "@vcmap/clipping-tool": "^3.0.0",
@@ -167,9 +167,9 @@
       }
     },
     "node_modules/@geoportallux/lux-3dviewer-plugin-auth": {
-      "version": "1.0.1-dev",
-      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-plugin-auth/-/lux-3dviewer-plugin-auth-1.0.1-dev.tgz",
-      "integrity": "sha512-MsW3oetckwS9ArzzQ3sEcPvcLrgdUny5fa935Mgz9mAmxEcvi0mb9i4uh9Z5RbOQ5QeKg41KxpBGWTHHXn7K9w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-plugin-auth/-/lux-3dviewer-plugin-auth-1.0.1.tgz",
+      "integrity": "sha512-N+c+yDEetRKukR0vJXcYIotGxHkUokRhYm6G+7JMhcx4CfQJgffO8cw70fkEsp1G5r1rgg9JAhqpLAna2mN7Ww==",
       "license": "GPL-3.0",
       "peerDependencies": {
         "@vcmap/core": "^6.3.7",
@@ -203,9 +203,9 @@
       }
     },
     "node_modules/@geoportallux/lux-3dviewer-themesync": {
-      "version": "1.5.1-beta",
-      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-themesync/-/lux-3dviewer-themesync-1.5.1-beta.tgz",
-      "integrity": "sha512-aoItqlt0OgovnCfzYCZa0GkjhUBD7oakLiwH6kzIP1XA9/HWZjjRoeLCup2HfdDRqP+ALDvvv1zDCK8tW9+l6Q==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-themesync/-/lux-3dviewer-themesync-1.5.1.tgz",
+      "integrity": "sha512-Bqeunv0OWLmmHSgn0fwOuX3ZLsbhPcw6oXY4H1lE8CM0iSHLul+O4OeWPLFoJFiKSgTbfA8QZEsE5onD3QIR9Q==",
       "license": "GPL-3.0",
       "dependencies": {
         "@zip.js/zip.js": "2.7.34"

--- a/plugins/package-lock.json
+++ b/plugins/package-lock.json
@@ -5,9 +5,10 @@
   "packages": {
     "": {
       "dependencies": {
+        "@geoportallux/lux-3dviewer-plugin-auth": "^1.0.0",
         "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal": "^1.2.2",
         "@geoportallux/lux-3dviewer-plugin-create-link": "^1.0.0",
-        "@geoportallux/lux-3dviewer-themesync": "^1.4.7",
+        "@geoportallux/lux-3dviewer-themesync": "^1.5.0",
         "@vcmap/cesium-filters": "^2.0.0",
         "@vcmap/cesium-inspector": "^2.0.0",
         "@vcmap/clipping-tool": "^3.0.0",
@@ -165,6 +166,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@geoportallux/lux-3dviewer-plugin-auth": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-plugin-auth/-/lux-3dviewer-plugin-auth-1.0.0.tgz",
+      "integrity": "sha512-GxPOELNtSi9LZ0SPlH+A23OsdNdoUO4AuOuvT1tBtztV2T8RfbbT/cGya1paDjJjgKyYMADV2LOCQXvesijhmA==",
+      "license": "GPL-3.0",
+      "peerDependencies": {
+        "@vcmap/core": "^6.3.7",
+        "@vcmap/ui": "^6.3.6",
+        "vue": "~3.4.38",
+        "vuetify": "~3.7.14"
+      }
+    },
     "node_modules/@geoportallux/lux-3dviewer-plugin-back-to-2d-portal": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-plugin-back-to-2d-portal/-/lux-3dviewer-plugin-back-to-2d-portal-1.2.2.tgz",
@@ -190,9 +203,9 @@
       }
     },
     "node_modules/@geoportallux/lux-3dviewer-themesync": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-themesync/-/lux-3dviewer-themesync-1.4.7.tgz",
-      "integrity": "sha512-rnyWHYq4g9mf6YsLddrsPTs2BNY2BGe9lldbYGNM5aEHPSzLHargxBG1Lz0wY6yYkAlF4HxfsHASTVqPIUNb2Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-themesync/-/lux-3dviewer-themesync-1.5.0.tgz",
+      "integrity": "sha512-Btcfm7veq7utPJkfJD0l8fWOyMAHkdOcUV/VjVfGzDSWtAyZAcqh9r6Z0M86CweZ0Qz/0GChd+3fVNbbvU2O2g==",
       "license": "GPL-3.0",
       "dependencies": {
         "@zip.js/zip.js": "2.7.34"
@@ -661,9 +674,9 @@
       }
     },
     "node_modules/@vcmap/core": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/@vcmap/core/-/core-6.3.5.tgz",
-      "integrity": "sha512-q/qGL9uoEpcCpe8b5NbP1Jc//fae8sFb/YLBxALFMXh0jD9LSFVk+XnelHx2vUf/6QWkAxmGsv8oc4WOacQE7A==",
+      "version": "6.3.8",
+      "resolved": "https://registry.npmjs.org/@vcmap/core/-/core-6.3.8.tgz",
+      "integrity": "sha512-Z5UN3qYoMhNM+xMOjI4rARSrZWF0X1M4DVX8dpwFhRSoaq+GiGJ3D0LRTM22UcLf1791/iyTAWzz2DzzHzjMBA==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,

--- a/plugins/package-lock.json
+++ b/plugins/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@geoportallux/lux-3dviewer-plugin-auth": "^1.0.0",
+        "@geoportallux/lux-3dviewer-plugin-auth": "1.0.1-dev",
         "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal": "^1.2.2",
         "@geoportallux/lux-3dviewer-plugin-create-link": "^1.0.0",
         "@geoportallux/lux-3dviewer-themesync": "1.5.1-beta",
@@ -167,9 +167,9 @@
       }
     },
     "node_modules/@geoportallux/lux-3dviewer-plugin-auth": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-plugin-auth/-/lux-3dviewer-plugin-auth-1.0.0.tgz",
-      "integrity": "sha512-GxPOELNtSi9LZ0SPlH+A23OsdNdoUO4AuOuvT1tBtztV2T8RfbbT/cGya1paDjJjgKyYMADV2LOCQXvesijhmA==",
+      "version": "1.0.1-dev",
+      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-plugin-auth/-/lux-3dviewer-plugin-auth-1.0.1-dev.tgz",
+      "integrity": "sha512-MsW3oetckwS9ArzzQ3sEcPvcLrgdUny5fa935Mgz9mAmxEcvi0mb9i4uh9Z5RbOQ5QeKg41KxpBGWTHHXn7K9w==",
       "license": "GPL-3.0",
       "peerDependencies": {
         "@vcmap/core": "^6.3.7",

--- a/plugins/package-lock.json
+++ b/plugins/package-lock.json
@@ -8,7 +8,7 @@
         "@geoportallux/lux-3dviewer-plugin-auth": "^1.0.0",
         "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal": "^1.2.2",
         "@geoportallux/lux-3dviewer-plugin-create-link": "^1.0.0",
-        "@geoportallux/lux-3dviewer-themesync": "1.5.1-alpha",
+        "@geoportallux/lux-3dviewer-themesync": "1.5.1-beta",
         "@vcmap/cesium-filters": "^2.0.0",
         "@vcmap/cesium-inspector": "^2.0.0",
         "@vcmap/clipping-tool": "^3.0.0",
@@ -203,9 +203,9 @@
       }
     },
     "node_modules/@geoportallux/lux-3dviewer-themesync": {
-      "version": "1.5.1-alpha",
-      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-themesync/-/lux-3dviewer-themesync-1.5.1-alpha.tgz",
-      "integrity": "sha512-rSfA6MspxIKS6Nwly5oYQML5jVti8M+PsEXiY/ZaAlA4TPwHQUb/2JZ9L15L7cqAsflFBar3HkRHt8K23QJCwg==",
+      "version": "1.5.1-beta",
+      "resolved": "https://registry.npmjs.org/@geoportallux/lux-3dviewer-themesync/-/lux-3dviewer-themesync-1.5.1-beta.tgz",
+      "integrity": "sha512-aoItqlt0OgovnCfzYCZa0GkjhUBD7oakLiwH6kzIP1XA9/HWZjjRoeLCup2HfdDRqP+ALDvvv1zDCK8tW9+l6Q==",
       "license": "GPL-3.0",
       "dependencies": {
         "@zip.js/zip.js": "2.7.34"

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -3,7 +3,7 @@
     "@geoportallux/lux-3dviewer-themesync": "1.5.1-beta",
     "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal": "^1.2.2",
     "@geoportallux/lux-3dviewer-plugin-create-link": "^1.0.0",
-    "@geoportallux/lux-3dviewer-plugin-auth": "^1.0.0",
+    "@geoportallux/lux-3dviewer-plugin-auth": "1.0.1-dev",
     "@vcmap/print": "^4.0.0",
     "@vcmap/walk": "^2.0.0",
     "@vcmap/clipping-tool": "^3.0.0",

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@geoportallux/lux-3dviewer-themesync": "1.5.2-dev",
-    "@geoportallux/lux-3dviewer-plugin-statesync": "1.0.0-dev",
+    "@geoportallux/lux-3dviewer-plugin-statesync": "1.0.0-alpha",
     "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal": "^1.2.2",
     "@geoportallux/lux-3dviewer-plugin-create-link": "^1.0.0",
     "@geoportallux/lux-3dviewer-plugin-auth": "1.0.1",

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -1,8 +1,9 @@
 {
   "dependencies": {
-    "@geoportallux/lux-3dviewer-themesync": "^1.4.7",
+    "@geoportallux/lux-3dviewer-themesync": "^1.5.0",
     "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal": "^1.2.2",
     "@geoportallux/lux-3dviewer-plugin-create-link": "^1.0.0",
+    "@geoportallux/lux-3dviewer-plugin-auth": "^1.0.0",
     "@vcmap/print": "^4.0.0",
     "@vcmap/walk": "^2.0.0",
     "@vcmap/clipping-tool": "^3.0.0",

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@geoportallux/lux-3dviewer-themesync": "1.5.1-alpha",
+    "@geoportallux/lux-3dviewer-themesync": "1.5.1-beta",
     "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal": "^1.2.2",
     "@geoportallux/lux-3dviewer-plugin-create-link": "^1.0.0",
     "@geoportallux/lux-3dviewer-plugin-auth": "^1.0.0",

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "@geoportallux/lux-3dviewer-themesync": "1.5.2-dev",
-    "@geoportallux/lux-3dviewer-plugin-statesync": "1.0.0-alpha",
+    "@geoportallux/lux-3dviewer-themesync": "1.5.2",
+    "@geoportallux/lux-3dviewer-plugin-statesync": "1.0.0",
     "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal": "^1.2.2",
     "@geoportallux/lux-3dviewer-plugin-create-link": "^1.0.0",
     "@geoportallux/lux-3dviewer-plugin-auth": "1.0.1",

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@geoportallux/lux-3dviewer-themesync": "^1.5.0",
+    "@geoportallux/lux-3dviewer-themesync": "1.5.1-dev",
     "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal": "^1.2.2",
     "@geoportallux/lux-3dviewer-plugin-create-link": "^1.0.0",
     "@geoportallux/lux-3dviewer-plugin-auth": "^1.0.0",

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "@geoportallux/lux-3dviewer-themesync": "1.5.1-beta",
+    "@geoportallux/lux-3dviewer-themesync": "1.5.1",
     "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal": "^1.2.2",
     "@geoportallux/lux-3dviewer-plugin-create-link": "^1.0.0",
-    "@geoportallux/lux-3dviewer-plugin-auth": "1.0.1-dev",
+    "@geoportallux/lux-3dviewer-plugin-auth": "1.0.1",
     "@vcmap/print": "^4.0.0",
     "@vcmap/walk": "^2.0.0",
     "@vcmap/clipping-tool": "^3.0.0",

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@geoportallux/lux-3dviewer-themesync": "1.5.1-dev",
+    "@geoportallux/lux-3dviewer-themesync": "1.5.1-alpha",
     "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal": "^1.2.2",
     "@geoportallux/lux-3dviewer-plugin-create-link": "^1.0.0",
     "@geoportallux/lux-3dviewer-plugin-auth": "^1.0.0",

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-    "@geoportallux/lux-3dviewer-themesync": "1.5.1",
+    "@geoportallux/lux-3dviewer-themesync": "1.5.2-dev",
+    "@geoportallux/lux-3dviewer-plugin-statesync": "1.0.0-dev",
     "@geoportallux/lux-3dviewer-plugin-back-to-2d-portal": "^1.2.2",
     "@geoportallux/lux-3dviewer-plugin-create-link": "^1.0.0",
     "@geoportallux/lux-3dviewer-plugin-auth": "1.0.1",


### PR DESCRIPTION
PR

- adds lux-3dviewer-plugin-auth package & config => allows login in 3dviewer
- updates lux-3dviewer-themesync package & config => adds credentials/cookie for themes and layer requests

:warning:  Important: Make sure to not include any `cache_version=0` param in `luxThemesUrl` to prevent caching issues after login/logout.

- [x] :warning:  Before merging this PR, all PRs of the 3 plugins need to be merged and versions released

This PR depends on the following PRs:

Themesync plugin:

- https://github.com/Geoportail-Luxembourg/3dviewer-themesync/pull/25
- https://github.com/Geoportail-Luxembourg/3dviewer-themesync/pull/26
- https://github.com/Geoportail-Luxembourg/3dviewer-themesync/pull/27

Auth plugin:

- https://github.com/Geoportail-Luxembourg/3dviewer-plugin-auth/pull/1
- https://github.com/Geoportail-Luxembourg/3dviewer-plugin-auth/pull/2

Statesync plugin:

- https://github.com/Geoportail-Luxembourg/3dviewer-plugin-statesync/pull/1

To test with local docker compo :

- Replace:
  - https://map.geoportail.lu => http://localhost:8080
  - "credentials": "same-origin" => "credentials": "include"

to:

```

    {
      "name": "@geoportallux/lux-3dviewer-themesync",
      "entry": "plugins/@geoportallux/lux-3dviewer-themesync/index.js",
      "luxThemesUrl": "http://localhost:8080/themes?limit=30&partitionlimit=5&interface=main&background=background",
      "luxI18nUrl": "https://map.geoportail.lu/static/0",
      "luxOwsUrl": "http://localhost:8080/public_map_layers/service",
      "luxWmtsUrl": "http://localhost:8080/mapproxy_4_v3/wmts",
      "lux3dUrl": "https://acts3.geoportail.lu/3d-data/3d-tiles",
      "luxLegendUrl": "https://3d.geoportail.lu/legends/get_html",
      "luxDefaultBaselayer": "orthogr_2013_global",
      "luxGeonetworkUrl": "https://geocatalogue.geoportail.lu/geonetwork/srv",
      "credentials": "include"
    },
    {
      "name": "@geoportallux/lux-3dviewer-plugin-auth",
      "entry": "plugins/@geoportallux/lux-3dviewer-plugin-auth/index.js",
      "baseUrl": "http://localhost:8080",
      "credentials": "include"
    },
```

- add `localhost` to `CORS_ALLOWED_ORIGINS` on backend
- add `ALLOW_CORS` to geoportal service and ALLOW_CORS=1 to `env.project`
- change `roleTheme` of test user in ldif to 1 for example

=> check that restricted themes are fetched
=> check that login works in 3dviewer & geoportal and login state is shared (via cookie) 
=> check that cookie is used in geoportal and 3dviewer (independent where login happened)
=> check that cookie is present on layer fetches (did not test layer display locally as cookie will not be attached fro different origins)